### PR TITLE
Enable SequenceParallel in te.LayerNormMLP layer

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -476,6 +476,8 @@ class MPTModel(MPTPreTrainedModel):
 
     # FSDP Wrap function
     def fsdp_wrap_fn(self, module):
+        if hasattr(module, '_fsdp_process_group'):
+            return {'process_group': module._fsdp_process_group}
         return isinstance(module, MPTBlock)
 
     # Activation Checkpointing

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -708,7 +708,7 @@ class ComposerMPTCausalLM(HuggingFaceModel):
             allow_embedding_resizing=True,
         )
 
-        self.n_active_params = sum(p.numel() for p in self.parameters())
+        self._n_active_params = None
 
         loss_fn_config = om_model_config.get('loss_fn', 'fused_crossentropy')
         if loss_fn_config == 'fused_crossentropy':
@@ -752,6 +752,21 @@ class ComposerMPTCausalLM(HuggingFaceModel):
         targets = self.get_targets(batch)
         return self.loss_fn(outputs.logits.view(-1, outputs.logits.size(-1)),
                             targets.view(-1))
+
+    @property
+    def n_active_params(self):
+        if self._n_active_params is not None:
+            return self._n_active_params
+
+        ffn_type = self.model.config.ffn_config['ffn_type']
+        if ffn_type == 'te_ln_mlp':
+            _cls = FFN_CLASS_REGISTRY[ffn_type]
+            self._n_active_params = _cls.parent_n_active_params(self)
+        else:
+            # default behavior
+            self._n_active_params = sum(p.numel() for p in self.parameters())
+
+        return self._n_active_params
 
     def flops_per_batch(self, batch):
         # Note: this computation does not take into account padding, and assumes

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -239,7 +239,10 @@ def main(cfg):
             print_trainable_parameters(model)  # should not be 100%
         else:  # standard model
             model = build_composer_model(cfg.model, tokenizer)
-    cfg.n_params = sum(p.numel() for p in model.parameters())
+    if hasattr(model, 'n_active_params'):
+        cfg.n_params = model.n_active_params
+    else:
+        cfg.n_params = sum(p.numel() for p in model.parameters())
     print(f'{cfg.n_params=:.2e}')
 
     # Dataloaders


### PR DESCRIPTION
Given https://github.com/mosaicml/llm-foundry/pull/432 we can relatively easily enable SequenceParallel training.

This branch is just for testing for now; if it works well, we can consider merging it.

Note: I'm pretty sure model ckpt using tp, then load without tp will be a headache and will require tooling be built.